### PR TITLE
query failed error at order-watcher

### DIFF
--- a/src/order_watcher.ts
+++ b/src/order_watcher.ts
@@ -66,8 +66,11 @@ export class OrderWatcher implements OrderWatcherInterface {
         if (filledOrders.length > 0) {
             throw new Error(`already fully filled orders ${JSON.stringify(filledOrders)}`);
         }
-        // Saves all given entities in the database. If entities do not exist in the database then inserts, otherwise updates.
-        await this._connection.getRepository(SignedOrderV4Entity).save(validOrders);
+        // Saves all specified entities with hash duplicates removed in the database. If entities do not exist in the database then inserts, otherwise updates.
+        const uniqueValidOrders = Array.from(
+            new Map(validOrders.map((order) => [order.hash, order]))
+        );
+        await this._connection.getRepository(SignedOrderV4Entity).save(uniqueValidOrders.values);
     }
 
     /// @dev


### PR DESCRIPTION
https://www.notion.so/shinonome-inc/query-failed-error-at-order-watcher-1fe2ca2168e14478b7d8544d614c34bd

`SignedOrderV4Entity`を保存する時のみhashの重複を取り除くように変更しました。
https://github.com/shinonome-inc/0x-order-watcher/pull/19#discussion_r1067835965

https://github.com/shinonome-inc/0x-order-watcher/pull/19
こちらのpull requestでコメントしていただいた内容を元に再度修正しました。