### PR TITLE
order-watcherで無効な注文がDBから消えないバグ調査

### DIFF
--- a/src/order_watcher.ts
+++ b/src/order_watcher.ts
@@ -116,7 +116,7 @@ export class OrderWatcher implements OrderWatcherInterface {
         if (ordersRemove.length > 0) {
             await this._connection
                 .getRepository(SignedOrderV4Entity)
-                .delete(ordersRemove.map((order) => order.hash as any));
+                .remove(ordersRemove);
             logger.info(`remove orders: ${validOrders.reduce((acc, order) => `${order?.hash}, ${acc}`, '')}`);
         }
     }

--- a/src/order_watcher.ts
+++ b/src/order_watcher.ts
@@ -113,6 +113,7 @@ export class OrderWatcher implements OrderWatcherInterface {
         }
         // remove orders
         const ordersRemove = invalidOrders.concat(canceledOrders, expiredOrderEntities, filledOrders);
+        logger.debug(`target remove orders: ${ordersRemove}`)
         if (ordersRemove.length > 0) {
             await this._connection
                 .getRepository(SignedOrderV4Entity)


### PR DESCRIPTION
- typeormが提供しているrepository APIの`delete`を利用していましたが`remove`を利用するように変更しました。
- そもそも`ordersRemove`を取得できているのかを確認するためにloggerを追加しました