### PR TITLE
Fix filter orders

### DIFF
--- a/delete_all_orders.sql
+++ b/delete_all_orders.sql
@@ -1,0 +1,10 @@
+-- SQLBook: Code
+-- Active: 1663118992615@@127.0.0.1@5432@api@public
+
+-- SQLBook: Code
+SELECT * FROM signed_orders_v4 LIMIT 100;
+
+DELETE FROM signed_orders_v4;
+-- SQLBook: Code
+
+

--- a/src/order_watcher.ts
+++ b/src/order_watcher.ts
@@ -190,17 +190,25 @@ export class OrderWatcher implements OrderWatcherInterface {
                 `order is ${OrderStatus[_info.status]} hash: ${_info.orderHash} info: ${_info} actualFillableTakerTokenAmount: ${_actualFillableTakerTokenAmount}`,
             );
 
-            if (_actualFillableTakerTokenAmount.gt(0) && _info.status === OrderStatus.FILLABLE) {
-                validOrderEntities.push(entity);
-            } else if (_info.status === OrderStatus.INVALID || _actualFillableTakerTokenAmount.isZero()) {
-                invalidOrderEntities.push(entity);
-            } else if (_info.status === OrderStatus.FILLED) {
-                filledOrderEntities.push(entity);
-            } else if (_info.status === OrderStatus.CANCELLED) {
-                canceledOrderEntities.push(entity);
-            } else if (_info.status === OrderStatus.EXPIRED) {
+            if (_info.status === OrderStatus.EXPIRED) {
                 expiredOrderEntities.push(entity);
             }
+            // NOTE: CANCELEDの注文は、_actualFillableTakerTokenAmountが0になっている。
+            else if (_info.status === OrderStatus.CANCELLED) {
+                canceledOrderEntities.push(entity);
+            }
+            else if (_info.status === OrderStatus.FILLED) {
+                filledOrderEntities.push(entity);
+            }
+            // XXX: FILLABLEの注文は、_actualFillableTakerTokenAmountが0より大きいとは限らないはず。
+            // makerの残高やallowanceが足りない場合は、_actualFillableTakerTokenAmountが0になる。(ZeroExのコード確認済み)
+            else if (_info.status === OrderStatus.FILLABLE && _actualFillableTakerTokenAmount.gt(0)) {
+                validOrderEntities.push(entity);
+            }
+            else if (_info.status === OrderStatus.INVALID || _actualFillableTakerTokenAmount.isZero()) {
+                invalidOrderEntities.push(entity);
+            }
+            // NOTE: ここには来ないはず
         }
         logger.debug(`_filterFreshOrders returns: validOrderEntities:>> ${validOrderEntities} `);
         logger.debug(`_filterFreshOrders returns: invalidOrderEntities:>> ${invalidOrderEntities} `);

--- a/src/order_watcher.ts
+++ b/src/order_watcher.ts
@@ -209,6 +209,7 @@ export class OrderWatcher implements OrderWatcherInterface {
                 invalidOrderEntities.push(entity);
             }
             // NOTE: ここには来ないはず
+            logger.warn(`unknown order status: ${_info.status}`);
         }
         logger.debug(`_filterFreshOrders returns: validOrderEntities:>> ${validOrderEntities} `);
         logger.debug(`_filterFreshOrders returns: invalidOrderEntities:>> ${invalidOrderEntities} `);


### PR DESCRIPTION
# 変更点
 -　_filterFreshOrdersで orderStatusから注文を分類するフィルタリングの順番
 - 一度にzeroexにクエリする注文の数を一回あたり200に制限することで、calldataが大きすぎることによるrpcリクエストエラーを解消を試みた。
 
# 結果
 -　削除すべき注文が削除できている。
 -